### PR TITLE
Ban lower than .3 for pingpong

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ MirahezeBots-jsonparser>=1.0.0,<2.0.0
 # code migrated to own repo awaiting bundle switch
 sopel-plugins.adminlist>=1.0.3
 sopel-plugins.channelmgnt>=1.0.3
-sopel-plugins.pingpong>=1.0.1
+sopel-plugins.pingpong>=1.0.3
 sopel-plugins.joinall>=1.0.0


### PR DESCRIPTION
I'd like to ensure when it goes out, everyone is using the latest version of any plugin by us.